### PR TITLE
Use `pkgdir`

### DIFF
--- a/script/2_PowerSystems_examples/03_parse_psse.jl
+++ b/script/2_PowerSystems_examples/03_parse_psse.jl
@@ -15,7 +15,7 @@ using TimeSeries
 # PowerSystems.jl links to some test data that is suitable for this example.
 # Let's download the test data
 PowerSystems.download(PowerSystems.TestData; branch = "master")
-base_dir = dirname(dirname(pathof(PowerSystems)));
+base_dir = pkgdir(PowerSystems);
 
 # ### Create a `System`
 

--- a/script/2_PowerSystems_examples/04_parse_tabulardata.jl
+++ b/script/2_PowerSystems_examples/04_parse_tabulardata.jl
@@ -18,7 +18,7 @@ using Dates
 # PowerSystems.jl links to some test data that is suitable for this example.
 # Let's download the test data
 PowerSystems.download(PowerSystems.TestData; branch = "master") # *note* add `force=true` to get a fresh copy
-base_dir = dirname(dirname(pathof(PowerSystems)));
+base_dir = pkgdir(PowerSystems);
 
 # ### The tabular data format relies on a folder containing `*.csv` files and a `user_descriptors.yaml` file
 # First, we'll read the tabular data

--- a/script/2_PowerSystems_examples/05_add_forecasts.jl
+++ b/script/2_PowerSystems_examples/05_add_forecasts.jl
@@ -15,7 +15,7 @@ using SIIPExamples
 using PowerSystems
 using JSON3
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(joinpath(pkgpath, "test", "2_PowerSystems_examples", "02_parse_matpower.jl"))
 
 # ### Define pointers to time series files

--- a/script/2_PowerSystems_examples/06_serialize_data.jl
+++ b/script/2_PowerSystems_examples/06_serialize_data.jl
@@ -12,7 +12,7 @@
 # Let's use a dataset from the [tabular data parsing example](https://nbviewer.jupyter.org/github/NREL-SIIP/SIIPExamples.jl/blob/master/notebook/2_PowerSystems_examples/parse_matpower.ipynb)
 using SIIPExamples
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(joinpath(pkgpath, "test", "2_PowerSystems_examples", "02_parse_matpower.jl"))
 
 # ### Write data to a temporary directory

--- a/script/2_PowerSystems_examples/07_network_matrices.jl
+++ b/script/2_PowerSystems_examples/07_network_matrices.jl
@@ -15,7 +15,7 @@
 # Let's use a dataset from the [tabular data parsing example](https://nbviewer.jupyter.org/github/NREL-SIIP/SIIPExamples.jl/blob/master/notebook/2_PowerSystems_examples/parse_matpower.ipynb)
 using SIIPExamples
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(joinpath(pkgpath, "test", "2_PowerSystems_examples", "02_parse_matpower.jl"))
 
 # ### Ybus

--- a/script/2_PowerSystems_examples/08_US_system.jl
+++ b/script/2_PowerSystems_examples/08_US_system.jl
@@ -23,7 +23,7 @@ using CSV
 # PowerSystems.jl links to some test data that is suitable for this example.
 # Let's download the test data
 println("downloading data...")
-datadir = joinpath(dirname(dirname(pathof(SIIPExamples))), "US-System")
+datadir = joinpath(pkgdir(SIIPExamples), "US-System")
 siip_data = joinpath(datadir, "SIIP")
 if !isdir(datadir)
     mkdir(datadir)
@@ -34,7 +34,7 @@ if !isdir(datadir)
 end
 
 config_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "2_PowerSystems_examples",
     "US_config",

--- a/script/2_PowerSystems_examples/09_loading_dynamic_systems_data.jl
+++ b/script/2_PowerSystems_examples/09_loading_dynamic_systems_data.jl
@@ -58,7 +58,7 @@ const PSY = PowerSystems
 # To create the system you need to pass the location of the RAW file
 
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/script/3_PowerSimulations_examples/02_sequential_simulations.jl
+++ b/script/3_PowerSimulations_examples/02_sequential_simulations.jl
@@ -14,7 +14,7 @@
 # simulation in PowerSimulations, we will build on the [OperationsProblem example](https://nbviewer.jupyter.org/github/NREL-SIIP/SIIPExamples.jl/blob/master/notebook/3_PowerSimulations_examples/01_operations_problems.ipynb)
 # by sourcing it as a dependency.
 using SIIPExamples
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(
     joinpath(pkgpath, "test", "3_PowerSimulations_examples", "01_operations_problems.jl"),
 )
@@ -128,7 +128,7 @@ sim = Simulation(
     steps = 1,
     problems = problems,
     sequence = DA_RT_sequence,
-    simulation_folder = dirname(dirname(pathof(SIIPExamples))),
+    simulation_folder = pkgdir(SIIPExamples),
 )
 
 # ### Build simulation

--- a/script/3_PowerSimulations_examples/04_bar_stack_plots.jl
+++ b/script/3_PowerSimulations_examples/04_bar_stack_plots.jl
@@ -10,7 +10,7 @@
 #
 # ## Dependencies
 using SIIPExamples #for path locations
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 using PowerSystems #to load results
 using PowerSimulations #to load results
 using PowerGraphics
@@ -21,7 +21,7 @@ using PowerSystemCaseBuilder
 # (If you haven't run some of the other simulations, you can run
 # `include(joinpath(pkgpath, "test", "3_PowerSimulations_examples", "02_sequential_simulations.jl"))`).
 # You can load the results into memory with:
-simulation_folder = joinpath(dirname(dirname(pathof(SIIPExamples))), "rts-test")
+simulation_folder = joinpath(pkgdir(SIIPExamples), "rts-test")
 simulation_folder =
     joinpath(simulation_folder, "$(maximum(parse.(Int64,readdir(simulation_folder))))")
 

--- a/script/3_PowerSimulations_examples/08_US-system-simulations.jl
+++ b/script/3_PowerSimulations_examples/08_US-system-simulations.jl
@@ -17,7 +17,7 @@ using PowerGraphics
 using Logging
 using Dates
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 PSI = PowerSimulations
 plotlyjs()
 

--- a/script/3_PowerSimulations_examples/09_tamu_simulation.jl
+++ b/script/3_PowerSimulations_examples/09_tamu_simulation.jl
@@ -9,7 +9,7 @@
 
 # ## Dependencies
 using SIIPExamples
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 using Dates
 
 # ### Modeling Packages

--- a/script/4_PowerSimulationsDynamics_examples/01_omib.jl
+++ b/script/4_PowerSimulationsDynamics_examples/01_omib.jl
@@ -31,7 +31,7 @@ PSD = PowerSimulationsDynamics
 # [dynamic systems data example](https://nbviewer.jupyter.org/github/NREL-SIIP/SIIPExamples.jl/blob/master/notebook/2_PowerSystems_examples/09_loading_dynamic_systems_data.ipynb)
 # previously to generate the json file._
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/script/4_PowerSimulationsDynamics_examples/02_line_dynamics.jl
+++ b/script/4_PowerSimulationsDynamics_examples/02_line_dynamics.jl
@@ -31,7 +31,7 @@ PSD = PowerSimulationsDynamics
 
 # # Step 2: Data creation
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/script/4_PowerSimulationsDynamics_examples/03_inverter_model.jl
+++ b/script/4_PowerSimulationsDynamics_examples/03_inverter_model.jl
@@ -29,7 +29,7 @@ PSD = PowerSimulationsDynamics
 # Create the system
 
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -5,7 +5,7 @@ abstract type PSYExamples <: Examples end
 abstract type PSIExamples <: Examples end
 abstract type PSDExamples <: Examples end
 
-const PACKAGE_DIR = dirname(dirname(pathof(SIIPExamples)))
+const PACKAGE_DIR = pkgdir(SIIPExamples)
 const SCRIPT_DIR = joinpath(PACKAGE_DIR, "script")
 const TEST_DIR = joinpath(PACKAGE_DIR, "test")
 const NB_DIR = joinpath(PACKAGE_DIR, "notebook")

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -135,7 +135,7 @@ Launches a notebook server for the specified `Examples` folder.
 `notebook(PSYExamples,  ".")`
 """
 function notebook(example::Type{<:Examples}, notebook_target_dir = nothing)
-    pkg_path = dirname(dirname(pathof(SIIPExamples)))
+    pkg_path = pkgdir(SIIPExamples)
     if isnothing(notebook_target_dir)
         in_pkg_path = startswith(pkg_path, pwd())
         notebook_target_dir = in_pkg_path ? NB_DIR : mktempdir()
@@ -157,7 +157,7 @@ end
 Prepend each notebook with an environment path
 """
 function set_env(str)
-    env_path = dirname(dirname(pathof(SIIPExamples)))
+    env_path = pkgdir(SIIPExamples)
     env_str = "] activate $(env_path)\n\n"
     return env_str * str
 end

--- a/test/2_PowerSystems_examples/03_parse_psse.jl
+++ b/test/2_PowerSystems_examples/03_parse_psse.jl
@@ -4,7 +4,7 @@ using PowerSystems
 using TimeSeries
 
 PowerSystems.download(PowerSystems.TestData; branch = "master")
-base_dir = dirname(dirname(pathof(PowerSystems)));
+base_dir = pkgdir(PowerSystems);
 
 sys = System(joinpath(base_dir, "data", "psse_raw", "RTS-GMLC.RAW"));
 

--- a/test/2_PowerSystems_examples/04_parse_tabulardata.jl
+++ b/test/2_PowerSystems_examples/04_parse_tabulardata.jl
@@ -5,7 +5,7 @@ using TimeSeries
 using Dates
 
 PowerSystems.download(PowerSystems.TestData; branch = "master") # *note* add `force=true` to get a fresh copy
-base_dir = dirname(dirname(pathof(PowerSystems)));
+base_dir = pkgdir(PowerSystems);
 
 RTS_GMLC_DIR = joinpath(base_dir, "data", "RTS_GMLC");
 rawsys = PowerSystems.PowerSystemTableData(

--- a/test/2_PowerSystems_examples/05_add_forecasts.jl
+++ b/test/2_PowerSystems_examples/05_add_forecasts.jl
@@ -4,7 +4,7 @@ using SIIPExamples
 using PowerSystems
 using JSON3
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(joinpath(pkgpath, "test", "2_PowerSystems_examples", "02_parse_matpower.jl"))
 
 FORECASTS_DIR = joinpath(base_dir, "forecasts", "5bus_ts")

--- a/test/2_PowerSystems_examples/06_serialize_data.jl
+++ b/test/2_PowerSystems_examples/06_serialize_data.jl
@@ -2,7 +2,7 @@
 
 using SIIPExamples
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(joinpath(pkgpath, "test", "2_PowerSystems_examples", "02_parse_matpower.jl"))
 
 folder = mktempdir()

--- a/test/2_PowerSystems_examples/07_network_matrices.jl
+++ b/test/2_PowerSystems_examples/07_network_matrices.jl
@@ -2,7 +2,7 @@
 
 using SIIPExamples
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(joinpath(pkgpath, "test", "2_PowerSystems_examples", "02_parse_matpower.jl"))
 
 ybus = Ybus(sys)

--- a/test/2_PowerSystems_examples/09_loading_dynamic_systems_data.jl
+++ b/test/2_PowerSystems_examples/09_loading_dynamic_systems_data.jl
@@ -5,7 +5,7 @@ using PowerSystems
 const PSY = PowerSystems
 
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/test/3_PowerSimulations_examples/02_sequential_simulations.jl
+++ b/test/3_PowerSimulations_examples/02_sequential_simulations.jl
@@ -1,7 +1,7 @@
 #! format: off
 
 using SIIPExamples
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 include(
     joinpath(pkgpath, "test", "3_PowerSimulations_examples", "01_operations_problems.jl"),
 )
@@ -47,7 +47,7 @@ sim = Simulation(
     steps = 1,
     problems = problems,
     sequence = DA_RT_sequence,
-    simulation_folder = dirname(dirname(pathof(SIIPExamples))),
+    simulation_folder = pkgdir(SIIPExamples),
 )
 
 build!(sim)

--- a/test/3_PowerSimulations_examples/09_tamu_simulation.jl
+++ b/test/3_PowerSimulations_examples/09_tamu_simulation.jl
@@ -1,7 +1,7 @@
 #! format: off
 
 using SIIPExamples
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 using Dates
 
 using PowerSystems

--- a/test/4_PowerSimulationsDynamics_examples/01_omib.jl
+++ b/test/4_PowerSimulationsDynamics_examples/01_omib.jl
@@ -9,7 +9,7 @@ gr()
 PSD = PowerSimulationsDynamics
 
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/test/4_PowerSimulationsDynamics_examples/02_line_dynamics.jl
+++ b/test/4_PowerSimulationsDynamics_examples/02_line_dynamics.jl
@@ -8,7 +8,7 @@ using Plots
 PSD = PowerSimulationsDynamics
 
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/test/4_PowerSimulationsDynamics_examples/03_inverter_model.jl
+++ b/test/4_PowerSimulationsDynamics_examples/03_inverter_model.jl
@@ -11,7 +11,7 @@ gr()
 PSD = PowerSimulationsDynamics
 
 file_dir = joinpath(
-    dirname(dirname(pathof(SIIPExamples))),
+    pkgdir(SIIPExamples),
     "script",
     "4_PowerSimulationsDynamics_examples",
     "Data",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Logging
 
 using Test
 
-pkgpath = dirname(dirname(pathof(SIIPExamples)))
+pkgpath = pkgdir(SIIPExamples)
 testpath = joinpath(pkgpath, "test")
 
 exclude = ["US-system-simulations.jl", "08_US_system.jl"]


### PR DESCRIPTION
Since [Julia 1.4](https://github.com/JuliaLang/julia/blob/v1.4.2/NEWS.md), there is the very convenient `pkgdir` which many people overlook. Via code searches, I noticed that this repository uses a lot of `dirname(dirname(pathof(SomePackage)))` which is the same as `pkgdir(SomePackage)`, so this PR proposes to replace that.

This package has the Julia version lower bounded to Julia 1.5

https://github.com/NREL-SIIP/SIIPExamples.jl/blob/a5313ccd7a88a77af101f42d2b9cbc32a868362b/Project.toml#L62

So, it's safe to use `pkgdir`.